### PR TITLE
Remove duplicity in Query, UrlOptions and Url

### DIFF
--- a/htsget-search/src/htsget/mod.rs
+++ b/htsget-search/src/htsget/mod.rs
@@ -76,7 +76,7 @@ impl From<StorageError> for HtsGetError {
 pub struct Query {
   pub id: String,
   pub format: Option<Format>,
-  pub class: Option<Class>,
+  pub class: Class,
   /// Reference name
   pub reference_name: Option<String>,
   /// sequence start position (1-based)
@@ -93,7 +93,7 @@ impl Query {
     Self {
       id: id.into(),
       format: None,
-      class: None,
+      class: Class::Body,
       reference_name: None,
       start: None,
       end: None,
@@ -109,7 +109,7 @@ impl Query {
   }
 
   pub fn with_class(mut self, class: Class) -> Self {
-    self.class = Some(class);
+    self.class = class;
     self
   }
 
@@ -214,7 +214,7 @@ impl Default for Headers {
 pub struct Url {
   pub url: String,
   pub headers: Option<Headers>,
-  pub class: Option<Class>,
+  pub class: Class,
 }
 
 impl Url {
@@ -222,7 +222,7 @@ impl Url {
     Self {
       url: url.into(),
       headers: None,
-      class: None,
+      class: Class::Body,
     }
   }
 
@@ -232,7 +232,7 @@ impl Url {
   }
 
   pub fn with_class(mut self, class: Class) -> Self {
-    self.class = Some(class);
+    self.class = class;
     self
   }
 }

--- a/htsget-search/src/storage/local.rs
+++ b/htsget-search/src/storage/local.rs
@@ -78,10 +78,7 @@ impl Storage for LocalStorage {
         Headers::default().with_header("Range", format!("bytes={}-{}", range_start, range_end)),
       )
     };
-    let url = match options.class {
-      Some(class) => url.with_class(class),
-      None => url,
-    };
+    let url = url.with_class(options.class);
     Ok(url)
   }
 }

--- a/htsget-search/src/storage/mod.rs
+++ b/htsget-search/src/storage/mod.rs
@@ -155,7 +155,7 @@ impl Default for GetOptions {
 
 pub struct UrlOptions {
   range: BytesRange,
-  class: Option<Class>,
+  class: Class,
 }
 
 impl UrlOptions {
@@ -165,7 +165,7 @@ impl UrlOptions {
   }
 
   pub fn with_class(mut self, class: Class) -> Self {
-    self.class = Some(class);
+    self.class = class;
     self
   }
 }
@@ -174,7 +174,7 @@ impl Default for UrlOptions {
   fn default() -> Self {
     Self {
       range: BytesRange::default(),
-      class: None,
+      class: Class::Body,
     }
   }
 }
@@ -482,7 +482,10 @@ mod tests {
   #[test]
   fn get_options_with_max_length() {
     let result = GetOptions::default().with_max_length(1);
-    assert_eq!(result.range, BytesRange::default().with_start(0).with_end(1));
+    assert_eq!(
+      result.range,
+      BytesRange::default().with_start(0).with_end(1)
+    );
   }
 
   #[test]
@@ -495,13 +498,13 @@ mod tests {
   fn url_options_with_range() {
     let result = UrlOptions::default().with_range(BytesRange::default());
     assert_eq!(result.range, BytesRange::default());
-    assert_eq!(result.class, None);
+    assert_eq!(result.class, Class::Body);
   }
 
   #[test]
   fn url_options_with_class() {
     let result = UrlOptions::default().with_class(Class::Header);
     assert_eq!(result.range, BytesRange::default());
-    assert_eq!(result.class, Some(Class::Header));
+    assert_eq!(result.class, Class::Header);
   }
 }


### PR DESCRIPTION
Closes #27 

With this change there is only one way to represent a Query or a Url that
doesn't specify a class. 