### PR TITLE
Add Cargo.lock to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+Cargo.lock


### PR DESCRIPTION
If we aren't going to upload the Cargo.lock to the repository, I think we are better off adding it to the .gitignore, so it doesn't get added by accident